### PR TITLE
Release builds workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Build release binaries
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+            target: aarch64-apple-darwin
+            platform: macosx_arm64
+            ext: dylib
+            cross: false
+          - os: macos-latest
+            arch: x86_64
+            target: x86_64-apple-darwin
+            platform: macosx_x86_64
+            ext: dylib
+            cross: false
+          - os: self-hosted
+            arch: x64
+            target: aarch64-unknown-linux-gnu
+            platform: manylinux_aarch64
+            ext: so
+            cross: true
+          - os: self-hosted
+            arch: x64
+            target: i686-unknown-linux-gnu
+            platform: manylinux_i686
+            ext: so
+            cross: true
+          - os: self-hosted
+            arch: x64
+            target: x86_64-unknown-linux-gnu
+            platform: manylinux_x86_64
+            ext: so
+            cross: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: Setup build directory
+        run: mkdir builds
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target=${{ matrix.target }}
+          use-cross: ${{ matrix.cross }}
+      - name: Copy
+        run: cp target/${{ matrix.target }}/release/libviam.${{ matrix.ext }} builds/libviam-${{ matrix.platform }}.${{ matrix.ext }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: builds
+          path: builds


### PR DESCRIPTION
Manually create release builds and make them available for download.

This is the first step in a release process. Still need to be done sometime in the future:

- [ ] Versioning
- [ ] Creating a GH release via workflow
- [ ] Attaching these builds to the GH release