### PR TITLE
Use chashmap to remove mutexes

### DIFF
--- a/src/rpc/client_stream.rs
+++ b/src/rpc/client_stream.rs
@@ -1,18 +1,11 @@
-use super::base_stream::*;
+use super::{base_stream::*, webrtc::trailers_from_proto};
 use crate::gen::proto::rpc::webrtc::v1::{
     response::Type, Response, ResponseHeaders, ResponseMessage, ResponseTrailers,
 };
 use anyhow::Result;
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::Bytes;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
-
-pub struct ActiveWebRTCClientStream {
-    pub client_stream: Arc<Mutex<WebRTCClientStream>>,
-}
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub struct WebRTCClientStream {
     pub base_stream: WebRTCBaseStream,
@@ -28,7 +21,7 @@ impl WebRTCClientStream {
 
     // processes a response message, returns true if and only if message was actually
     // processed
-    fn process_message(&mut self, response: ResponseMessage) -> Result<bool> {
+    async fn process_message(&mut self, response: ResponseMessage) -> Result<bool> {
         let mut message_processed = false;
         if let Some(message) = response.packet_message {
             match self.base_stream.process_message(message) {
@@ -40,27 +33,10 @@ impl WebRTCClientStream {
                         message_buf.write_u32::<BigEndian>(len)?;
                         message_buf.append(&mut data);
                         let data = Bytes::from(message_buf);
-                        // when sending data synchronously, we run the risk of sending
-                        // too many messages too quickly, which results in messages being
-                        // dropped. Unfortunately we cannot send asynchronously under the
-                        // current code structure because mutexes don't play nicely with
-                        // async. this loop is ugly, but ensures that we properly send
-                        // all messages while still failing in cases where send is just
-                        // not possible.
-                        // TODO(RSDK-651) - we should refactor here so we can use the
-                        // async `send_data(data)` fn, eliminating the need for this loop.
-                        let now = std::time::SystemTime::now();
-                        let timeout = std::time::Duration::from_secs(5);
-                        loop {
-                            if now.elapsed().unwrap() >= timeout {
-                                return Err(anyhow::anyhow!("Error sending data: {data:?}"));
-                            }
-                            if let Ok(()) =
-                                self.base_stream.message_sender.try_send_data(data.clone())
-                            {
-                                break;
-                            }
-                        }
+                        self.base_stream
+                            .message_sender
+                            .send_data(data.clone())
+                            .await?;
                     }
                 }
 
@@ -72,9 +48,18 @@ impl WebRTCClientStream {
         Ok(message_processed)
     }
 
-    fn process_trailers(&mut self, trailers: ResponseTrailers) {
-        self.trailers_received.store(true, Ordering::Release);
+    async fn process_trailers(&mut self, trailers: ResponseTrailers) {
+        let trailers_to_send = trailers_from_proto(trailers.clone());
+        if let Err(e) = self
+            .base_stream
+            .message_sender
+            .send_trailers(trailers_to_send)
+            .await
+        {
+            log::error!("Error sending trailers to http response: {e}");
+        }
 
+        self.trailers_received.store(true, Ordering::Release);
         let err = match trailers.status {
             None => None,
             Some(status) => {
@@ -93,7 +78,7 @@ impl WebRTCClientStream {
 
     // processes response. returns true if and only if a message was sent and we're done
     // processing (i.e., trailers were processed)
-    pub fn on_response(&mut self, response: Response) -> Result<bool> {
+    pub async fn on_response(&mut self, response: Response) -> Result<bool> {
         match &response.r#type {
             Some(Type::Headers(headers)) => {
                 if self.headers_received.load(Ordering::Acquire) {
@@ -124,11 +109,11 @@ impl WebRTCClientStream {
                     return Err(err);
                 }
 
-                self.process_message(message.to_owned())
+                self.process_message(message.to_owned()).await
             }
 
             Some(Type::Trailers(trailers)) => {
-                self.process_trailers(trailers.to_owned());
+                self.process_trailers(trailers.to_owned()).await;
                 Ok(true)
             }
             None => Ok(false),

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -86,13 +86,7 @@ impl Service<http::Request<BoxBody>> for ViamChannel {
                 let fut = async move {
                     let (parts, body) = request.into_parts();
 
-                    let stream = channel
-                        .new_stream()
-                        .lock()
-                        .unwrap()
-                        .base_stream
-                        .stream
-                        .clone();
+                    let stream = channel.new_stream();
                     let stream_id = stream.id;
                     let metadata = Some(metadata_from_parts(&parts));
                     let headers = RequestHeaders {

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -1,12 +1,13 @@
-use crate::gen::proto::rpc::webrtc::v1::{IceServer, WebRtcConfig};
+use crate::gen::proto::rpc::webrtc::v1::{IceServer, ResponseTrailers, WebRtcConfig};
 use anyhow::Result;
 use bytes::Bytes;
 use core::fmt;
 use futures::Future;
-use http::Uri;
+use http::{header::HeaderName, HeaderMap, HeaderValue, Uri};
 use std::{
     hint,
     pin::Pin,
+    str::FromStr,
     sync::{atomic::AtomicBool, Arc},
     task::{Context, Poll},
     time::Duration,
@@ -302,4 +303,50 @@ pub async fn webrtc_action_with_timeout<T>(f: impl Future<Output = T>) -> Result
             }
         }
     }
+}
+
+pub fn trailers_from_proto(proto: ResponseTrailers) -> HeaderMap {
+    let mut trailers = HeaderMap::new();
+    if let Some(metadata) = proto.metadata {
+        let mut vals = metadata.md.iter();
+        while let Some((k, v)) = vals.next() {
+            let k = HeaderName::from_str(k);
+            let v = HeaderValue::from_str(&v.values.concat());
+            let (k, v) = match (k, v) {
+                (Ok(k), Ok(v)) => (k, v),
+                (Err(e), _) => {
+                    log::error!("Error converting proto trailer key: [{e}]");
+                    continue;
+                }
+                (_, Err(e)) => {
+                    log::error!("Error converting proto trailer value: [{e}]");
+                    continue;
+                }
+            };
+            trailers.insert(k, v);
+        }
+    };
+
+    let status_name = "grpc-status";
+    let status_code = match proto.status {
+        Some(ref status) => status.code.to_string(),
+        None => "0".to_string(),
+    };
+
+    let k = match HeaderName::from_str(status_name) {
+        Ok(k) => k,
+        Err(e) => {
+            log::error!("Error parsing HeaderName: {e}");
+            return trailers;
+        }
+    };
+    let v = match HeaderValue::from_str(&status_code) {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("Error parsing HeaderValue: {e}");
+            return trailers;
+        }
+    };
+    trailers.insert(k, v);
+    trailers
 }


### PR DESCRIPTION
replaces mutexes with concurrent hashmap, allowing for async data send.