### PR TITLE
RSDK-9518: upgrade upload artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ on:
         required: true
         default: nobump
         options:
-        - major
-        - minor
-        - patch
-        - nobump
+          - major
+          - minor
+          - patch
+          - nobump
 
 jobs:
   prepare:
@@ -30,7 +30,7 @@ jobs:
         with:
           organization: viamrobotics
           username: ${{ github.actor }}
-          token:  ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cancelling - user not part of organization
         uses: andymckay/cancel-action@0.2
@@ -65,7 +65,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           releaseName: v${{ steps.which_version.outputs.version }}
-          doNotFailIfNotFound: 'true'
+          doNotFailIfNotFound: "true"
 
       - name: Cancelling - release already exists
         uses: andymckay/cancel-action@0.2
@@ -176,3 +176,5 @@ jobs:
           draft: true
           prerelease: false
           fail_on_unmatched_files: true
+  #         prerelease: false
+  #         fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,72 +15,72 @@ on:
           - nobump
 
 jobs:
-  prepare:
-    # if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
-    outputs:
-      version: ${{ steps.which_version.outputs.version }}
-      sha: ${{ steps.commit.outputs.commit_long_sha }}
-    steps:
-      - name: Check if organization member
-        id: is_organization_member
-        uses: jamessingleton/is-organization-member@1.0.1
-        with:
-          organization: viamrobotics
-          username: ${{ github.actor }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # prepare:
+  #   if: github.repository_owner == 'viamrobotics'
+  #   runs-on: [self-hosted, x64]
+  #   container:
+  #     image: ghcr.io/viamrobotics/canon:amd64
+  #   outputs:
+  #     version: ${{ steps.which_version.outputs.version }}
+  #     sha: ${{ steps.commit.outputs.commit_long_sha }}
+  #   steps:
+  #     - name: Check if organization member
+  #       id: is_organization_member
+  #       uses: jamessingleton/is-organization-member@1.0.1
+  #       with:
+  #         organization: viamrobotics
+  #         username: ${{ github.actor }}
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cancelling - user not part of organization
-        uses: andymckay/cancel-action@0.2
-        if: |
-          steps.is_organization_member.outputs.result == 'false'
+  #     - name: Cancelling - user not part of organization
+  #       uses: andymckay/cancel-action@0.2
+  #       if: |
+  #         steps.is_organization_member.outputs.result == 'false'
 
-      - name: Checkout Code
-        uses: actions/checkout@v3
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v3
 
-      - name: Setup rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+  #     - name: Setup rust toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
 
-      - name: Bump Version
-        shell: bash
-        if: inputs.version != 'nobump'
-        run: |
-          cargo install cargo-bump
-          cargo bump ${{ inputs.version }}
+  #     - name: Bump Version
+  #       shell: bash
+  #       if: inputs.version != 'nobump'
+  #       run: |
+  #         cargo install cargo-bump
+  #         cargo bump ${{ inputs.version }}
 
-      - name: Which Version
-        id: which_version
-        shell: bash
-        run: |
-          echo "version=$(cargo pkgid | sed 's/.*@//g')" >> $GITHUB_OUTPUT
+  #     - name: Which Version
+  #       id: which_version
+  #       shell: bash
+  #       run: |
+  #         echo "version=$(cargo pkgid | sed 's/.*@//g')" >> $GITHUB_OUTPUT
 
-      - name: Check if release exists
-        uses: cardinalby/git-get-release-action@1.2.4
-        id: release_exists
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          releaseName: v${{ steps.which_version.outputs.version }}
-          doNotFailIfNotFound: "true"
+  #     - name: Check if release exists
+  #       uses: cardinalby/git-get-release-action@1.2.4
+  #       id: release_exists
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         releaseName: v${{ steps.which_version.outputs.version }}
+  #         doNotFailIfNotFound: "true"
 
-      - name: Cancelling - release already exists
-        uses: andymckay/cancel-action@0.2
-        if: steps.release_exists.outputs.id != ''
+  #     - name: Cancelling - release already exists
+  #       uses: andymckay/cancel-action@0.2
+  #       if: steps.release_exists.outputs.id != ''
 
-      - name: Commit + Push
-        id: commit
-        uses: EndBug/add-and-commit@v9.0.0
-        with:
-          default_author: github_actions
-          message: Bumping version to v${{ steps.which_version.outputs.version }} [skip ci]
+  #     - name: Commit + Push
+  #       id: commit
+  #       uses: EndBug/add-and-commit@v9.0.0
+  #       with:
+  #         default_author: github_actions
+  #         message: Bumping version to v${{ steps.which_version.outputs.version }} [skip ci]
 
   build_macos:
-    if: github.repository_owner == 'viamrobotics'
-    needs: [prepare]
+    # if: github.repository_owner == 'viamrobotics'
+    # needs: [prepare]
     runs-on: [self-hosted, ARM64, macOS]
     strategy:
       fail-fast: false
@@ -114,8 +114,8 @@ jobs:
           path: builds
 
   build_linux:
-    if: github.repository_owner == 'viamrobotics'
-    needs: [prepare]
+    # if: github.repository_owner == 'viamrobotics'
+    # needs: [prepare]
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/cross-rs/${{ matrix.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.prepare.outputs.sha }}
+        # with:
+        #   ref: ${{ needs.prepare.outputs.sha }}
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -135,8 +135,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.prepare.outputs.sha }}
+        # with:
+        #   ref: ${{ needs.prepare.outputs.sha }}
       - name: Setup rust toolchain
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,9 +108,9 @@ jobs:
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam.dylib builds/libviam-${{ matrix.platform }}.dylib
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: builds
+          name: macos-builds-${{ matrix.platform }}
           path: builds
 
   build_linux:
@@ -153,9 +153,9 @@ jobs:
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam.so builds/libviam-${{ matrix.platform }}.so
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: builds
+          name: linux-builds-${{ matrix.platform }}
           path: builds
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,8 +135,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        # with:
-        #   ref: ${{ needs.prepare.outputs.sha }}
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
       - name: Setup rust toolchain
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   prepare:
-    if: github.repository_owner == 'viamrobotics'
+    # if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
@@ -158,23 +158,21 @@ jobs:
           name: linux-builds-${{ matrix.platform }}
           path: builds
 
-  release:
-    needs: [prepare, build_macos, build_linux]
-    if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+  # release:
+  #   needs: [prepare, build_macos, build_linux]
+  #   if: github.repository_owner == 'viamrobotics'
+  #   runs-on: [self-hosted, x64]
+  #   container:
+  #     image: ghcr.io/viamrobotics/canon:amd64
 
-    steps:
-      - uses: actions/download-artifact@v3
+  #   steps:
+  #     - uses: actions/download-artifact@v3
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ needs.prepare.outputs.version }}
-          files: builds/*
-          draft: true
-          prerelease: false
-          fail_on_unmatched_files: true
+  #     - name: Release
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         tag_name: v${{ needs.prepare.outputs.version }}
+  #         files: builds/*
+  #         draft: true
   #         prerelease: false
   #         fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,72 +15,72 @@ on:
           - nobump
 
 jobs:
-  # prepare:
-  #   if: github.repository_owner == 'viamrobotics'
-  #   runs-on: [self-hosted, x64]
-  #   container:
-  #     image: ghcr.io/viamrobotics/canon:amd64
-  #   outputs:
-  #     version: ${{ steps.which_version.outputs.version }}
-  #     sha: ${{ steps.commit.outputs.commit_long_sha }}
-  #   steps:
-  #     - name: Check if organization member
-  #       id: is_organization_member
-  #       uses: jamessingleton/is-organization-member@1.0.1
-  #       with:
-  #         organization: viamrobotics
-  #         username: ${{ github.actor }}
-  #         token: ${{ secrets.GITHUB_TOKEN }}
+  prepare:
+    if: github.repository_owner == 'viamrobotics'
+    runs-on: [self-hosted, x64]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64
+    outputs:
+      version: ${{ steps.which_version.outputs.version }}
+      sha: ${{ steps.commit.outputs.commit_long_sha }}
+    steps:
+      - name: Check if organization member
+        id: is_organization_member
+        uses: jamessingleton/is-organization-member@1.0.1
+        with:
+          organization: viamrobotics
+          username: ${{ github.actor }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Cancelling - user not part of organization
-  #       uses: andymckay/cancel-action@0.2
-  #       if: |
-  #         steps.is_organization_member.outputs.result == 'false'
+      - name: Cancelling - user not part of organization
+        uses: andymckay/cancel-action@0.2
+        if: |
+          steps.is_organization_member.outputs.result == 'false'
 
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
 
-  #     - name: Setup rust toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
-  #     - name: Bump Version
-  #       shell: bash
-  #       if: inputs.version != 'nobump'
-  #       run: |
-  #         cargo install cargo-bump
-  #         cargo bump ${{ inputs.version }}
+      - name: Bump Version
+        shell: bash
+        if: inputs.version != 'nobump'
+        run: |
+          cargo install cargo-bump
+          cargo bump ${{ inputs.version }}
 
-  #     - name: Which Version
-  #       id: which_version
-  #       shell: bash
-  #       run: |
-  #         echo "version=$(cargo pkgid | sed 's/.*@//g')" >> $GITHUB_OUTPUT
+      - name: Which Version
+        id: which_version
+        shell: bash
+        run: |
+          echo "version=$(cargo pkgid | sed 's/.*@//g')" >> $GITHUB_OUTPUT
 
-  #     - name: Check if release exists
-  #       uses: cardinalby/git-get-release-action@1.2.4
-  #       id: release_exists
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         releaseName: v${{ steps.which_version.outputs.version }}
-  #         doNotFailIfNotFound: "true"
+      - name: Check if release exists
+        uses: cardinalby/git-get-release-action@1.2.4
+        id: release_exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseName: v${{ steps.which_version.outputs.version }}
+          doNotFailIfNotFound: "true"
 
-  #     - name: Cancelling - release already exists
-  #       uses: andymckay/cancel-action@0.2
-  #       if: steps.release_exists.outputs.id != ''
+      - name: Cancelling - release already exists
+        uses: andymckay/cancel-action@0.2
+        if: steps.release_exists.outputs.id != ''
 
-  #     - name: Commit + Push
-  #       id: commit
-  #       uses: EndBug/add-and-commit@v9.0.0
-  #       with:
-  #         default_author: github_actions
-  #         message: Bumping version to v${{ steps.which_version.outputs.version }} [skip ci]
+      - name: Commit + Push
+        id: commit
+        uses: EndBug/add-and-commit@v9.0.0
+        with:
+          default_author: github_actions
+          message: Bumping version to v${{ steps.which_version.outputs.version }} [skip ci]
 
   build_macos:
-    # if: github.repository_owner == 'viamrobotics'
-    # needs: [prepare]
+    if: github.repository_owner == 'viamrobotics'
+    needs: [prepare]
     runs-on: [self-hosted, ARM64, macOS]
     strategy:
       fail-fast: false
@@ -93,8 +93,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        # with:
-        #   ref: ${{ needs.prepare.outputs.sha }}
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -114,8 +114,8 @@ jobs:
           path: builds
 
   build_linux:
-    # if: github.repository_owner == 'viamrobotics'
-    # needs: [prepare]
+    if: github.repository_owner == 'viamrobotics'
+    needs: [prepare]
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/cross-rs/${{ matrix.image }}
@@ -158,21 +158,21 @@ jobs:
           name: linux-builds-${{ matrix.platform }}
           path: builds
 
-  # release:
-  #   needs: [prepare, build_macos, build_linux]
-  #   if: github.repository_owner == 'viamrobotics'
-  #   runs-on: [self-hosted, x64]
-  #   container:
-  #     image: ghcr.io/viamrobotics/canon:amd64
+  release:
+    needs: [prepare, build_macos, build_linux]
+    if: github.repository_owner == 'viamrobotics'
+    runs-on: [self-hosted, x64]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64
 
-  #   steps:
-  #     - uses: actions/download-artifact@v3
+    steps:
+      - uses: actions/download-artifact@v3
 
-  #     - name: Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         tag_name: v${{ needs.prepare.outputs.version }}
-  #         files: builds/*
-  #         draft: true
-  #         prerelease: false
-  #         fail_on_unmatched_files: true
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.prepare.outputs.version }}
+          files: builds/*
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: true


### PR DESCRIPTION
This change will cause multiple artifacts to be uploaded instead of just one, as per the [breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) introduced for v4.
> Uploading to the same named Artifact multiple times.
> 
> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

Wasn't really sure how to test this successfully, but based on my reading, the different named artifacts don't change anything because we download all the artifacts in the `release` step.